### PR TITLE
Improve setting descriptions

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -2,9 +2,9 @@ social_share_links:
   type: list
   default: ""
   description: 
-    en: 'Comma delimited in this order: name, icon, title, link.<br><b>Name:</b> The name of the social provider<br><b>Icon:</b> Choose a <a href="https://fontawesome.com/v4.7.0/icons/">Fontawesome icon</a><br><b>Title:</b> Text that appears when you move the mouse over the button<br><b>Link:</b> the share link. See the <a href="https://meta.discourse.org/t/social-share-component/89980">theme topic</a> for more details'
+    en: 'Comma delimited in this order: name, icon, title, link.<br><ul><li><b>Name:</b> The name of the social provider<br><b></li><li>Icon:</b> Choose a <a href="https://fontawesome.com/v5.15/icons?d=gallery&p=1&m=free">Fontawesome icon</a>. Use prefix <code>fa-</code> for solid icons, <code>far-</code> for regular icons and <code>fab-</code> for brand icons.<br><b></li><li>Title:</b> Text that appears when you move the mouse over the button<br><b></li><li>Link:</b> the share link. See the <a href="https://meta.discourse.org/t/social-share-component/89980">theme topic</a> for more details</li></ul>'
 svg_icons:
   default: ''
   type: 'list'
   list_type: 'compact'
-  description: 'List of FontAwesome 5 icons used in this theme component'
+  description: 'List of FontAwesome 5 icons used in this theme component. Use prefix <code>fa-</code> for solid icons, <code>far-</code> for regular icons and <code>fab-</code> for brand icons.'


### PR DESCRIPTION
This fixes the FA icon link and adds a little more clarity on how to use the icons in the settings.

<img width="724" alt="Screen Shot 2021-11-29 at 8 13 28 PM" src="https://user-images.githubusercontent.com/22733864/143986500-ae8442ab-42d2-4b3f-9854-07dad3d7a7df.png">

At some point it would be great to have an icon picker theme setting.